### PR TITLE
Fix and enable all tests for database query functions (Issue #16)

### DIFF
--- a/tests/test_database_queries.py
+++ b/tests/test_database_queries.py
@@ -65,7 +65,7 @@ def teardown_test_database():
 
 def add_test_word(word, pos="NOUN", is_regular=None, translation="test", difficulty=3):
     """Helper function to add a test word to the database."""
-    database.add_word(word, pos, is_regular, translation)
+    database.add_word(word, pos, is_regular, translation, difficulty)
 
 
 def add_test_temp_word(word, lemma, session_id, pos="NOUN", translation="test"):
@@ -342,8 +342,7 @@ def run_all_tests():
         # get_all_words tests
         test_get_all_words_empty,
         test_get_all_words_multiple,
-        # Skipping test_get_all_words_filter_difficulty due to test isolation issues
-        # Function works correctly - verified in test_debug.py
+        test_get_all_words_filter_difficulty,
         test_get_all_words_search_term,
         test_get_all_words_combined_filters,
         # get_all_sessions tests


### PR DESCRIPTION
## Summary
- Fixed bug in `add_test_word()` helper function that wasn't passing the difficulty parameter to `database.add_word()`
- Enabled `test_get_all_words_filter_difficulty()` test that was previously skipped due to this bug
- All 13 tests now pass successfully

## Test Coverage
This PR ensures comprehensive test coverage for all database query functions added in #15:

### `get_all_words()` Tests
- ✅ Empty database
- ✅ Multiple words
- ✅ Difficulty filtering
- ✅ Search by word term
- ✅ Search by translation term
- ✅ Combined filters (difficulty + search)
- ✅ Alphabetical ordering

### `get_all_sessions()` Tests
- ✅ Empty temp database
- ✅ Single session
- ✅ Multiple sessions
- ✅ Ordering (newest first)

### `get_session_stats()` Tests
- ✅ Valid session ID
- ✅ Invalid session ID
- ✅ Empty session
- ✅ Accurate counts

### `get_word_count()` Tests
- ✅ Empty database
- ✅ Multiple words
- ✅ Accurate counts

## Changes
- `tests/test_database_queries.py`:
  - Fixed `add_test_word()` to pass difficulty parameter
  - Uncommented and enabled `test_get_all_words_filter_difficulty()`

## Test Results
All 13 tests pass:
```
SUCCESS: All 13 tests passed!
```

## Closes
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)