### PR TITLE
Implement Review Queue tab UI (Issue #19)

### DIFF
--- a/src/ui/tabs/review_queue_tab.py
+++ b/src/ui/tabs/review_queue_tab.py
@@ -1,11 +1,18 @@
-"""Review Queue tab placeholder."""
+"""Review Queue tab for reviewing and approving/rejecting processed words."""
 
+import sys
+import os
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, messagebox
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from database import get_all_sessions, get_pending_words, approve_word, reject_word
 
 
 class ReviewQueueTab(ttk.Frame):
-    """Placeholder for Review Queue tab."""
+    """Tab for reviewing and approving/rejecting words from processing sessions."""
 
     def __init__(self, parent):
         """Initialize the Review Queue tab.
@@ -14,13 +21,413 @@ class ReviewQueueTab(ttk.Frame):
             parent: Parent widget (notebook)
         """
         super().__init__(parent)
+
+        # State management
+        self._current_session_id = None
+        self._words = []
+        self._current_index = 0
+        self._difficulty = tk.IntVar(value=3)  # Default: Medium
+
         self._setup_ui()
+        self._update_button_states()
 
     def _setup_ui(self):
-        """Set up the placeholder UI."""
-        label = ttk.Label(
-            self,
-            text="Review Queue - Coming Soon",
-            font=('Arial', 14)
+        """Set up the tab UI with session selector, word display, and actions."""
+        # Main container with padding
+        main_frame = ttk.Frame(self, padding="10")
+        main_frame.pack(fill='both', expand=True)
+
+        # Configure grid weights for responsive layout
+        main_frame.columnconfigure(0, weight=1)
+        main_frame.rowconfigure(1, weight=1)
+
+        # Top Section - Session Selection
+        self._create_session_section(main_frame)
+
+        # Middle Section - Word Display
+        self._create_word_display_section(main_frame)
+
+        # Bottom Section - Actions
+        self._create_actions_section(main_frame)
+
+    def _create_session_section(self, parent):
+        """Create the session selection section."""
+        session_frame = ttk.LabelFrame(parent, text="Session Selection", padding="10")
+        session_frame.grid(row=0, column=0, sticky='ew', pady=(0, 10))
+        session_frame.columnconfigure(1, weight=1)
+
+        # Session dropdown
+        ttk.Label(session_frame, text="Session:").grid(row=0, column=0, padx=(0, 10))
+
+        self.session_combo = ttk.Combobox(session_frame, state='readonly', width=50)
+        self.session_combo.grid(row=0, column=1, sticky='ew', padx=(0, 10))
+
+        # Load Session button
+        self.load_button = ttk.Button(
+            session_frame,
+            text="Load Session",
+            command=self._load_session
         )
-        label.pack(expand=True)
+        self.load_button.grid(row=0, column=2, padx=(0, 10))
+
+        # Refresh button
+        self.refresh_button = ttk.Button(
+            session_frame,
+            text="Refresh",
+            command=self._refresh_sessions
+        )
+        self.refresh_button.grid(row=0, column=3)
+
+        # Progress label
+        self.progress_label = ttk.Label(
+            session_frame,
+            text="No session loaded",
+            font=('Arial', 10)
+        )
+        self.progress_label.grid(row=1, column=0, columnspan=4, sticky='w', pady=(10, 0))
+
+    def _create_word_display_section(self, parent):
+        """Create the word display section."""
+        word_frame = ttk.LabelFrame(parent, text="Word Details", padding="20")
+        word_frame.grid(row=1, column=0, sticky='nsew', pady=(0, 10))
+        word_frame.columnconfigure(1, weight=1)
+
+        # Original form
+        ttk.Label(word_frame, text="Original:", font=('Arial', 10, 'bold')).grid(
+            row=0, column=0, sticky='w', pady=5
+        )
+        self.original_label = ttk.Label(word_frame, text="-", font=('Arial', 10))
+        self.original_label.grid(row=0, column=1, sticky='w', pady=5)
+
+        # Lemma (main word)
+        ttk.Label(word_frame, text="Lemma:", font=('Arial', 10, 'bold')).grid(
+            row=1, column=0, sticky='w', pady=5
+        )
+        self.lemma_label = ttk.Label(word_frame, text="-", font=('Arial', 14, 'bold'))
+        self.lemma_label.grid(row=1, column=1, sticky='w', pady=5)
+
+        # Part of Speech
+        ttk.Label(word_frame, text="POS:", font=('Arial', 10, 'bold')).grid(
+            row=2, column=0, sticky='w', pady=5
+        )
+        self.pos_label = ttk.Label(word_frame, text="-", font=('Arial', 10))
+        self.pos_label.grid(row=2, column=1, sticky='w', pady=5)
+
+        # Translation
+        ttk.Label(word_frame, text="Translation:", font=('Arial', 10, 'bold')).grid(
+            row=3, column=0, sticky='w', pady=5
+        )
+        self.translation_label = ttk.Label(word_frame, text="-", font=('Arial', 10))
+        self.translation_label.grid(row=3, column=1, sticky='w', pady=5)
+
+        # No word message (shown when no words to display)
+        self.no_word_label = ttk.Label(
+            word_frame,
+            text="Load a session to review words",
+            font=('Arial', 12),
+            foreground='gray'
+        )
+        self.no_word_label.grid(row=4, column=0, columnspan=2, pady=20)
+
+    def _create_actions_section(self, parent):
+        """Create the actions section with difficulty, tags, and buttons."""
+        actions_frame = ttk.LabelFrame(parent, text="Actions", padding="10")
+        actions_frame.grid(row=2, column=0, sticky='ew')
+        actions_frame.columnconfigure(0, weight=1)
+
+        # Difficulty selection
+        difficulty_frame = ttk.Frame(actions_frame)
+        difficulty_frame.grid(row=0, column=0, sticky='w', pady=(0, 10))
+
+        ttk.Label(difficulty_frame, text="Difficulty:", font=('Arial', 10, 'bold')).pack(side='left', padx=(0, 10))
+
+        difficulty_options = [
+            (0, "Known"),
+            (1, "Super Easy"),
+            (2, "Easy"),
+            (3, "Medium"),
+            (4, "Hard")
+        ]
+
+        for value, text in difficulty_options:
+            rb = ttk.Radiobutton(
+                difficulty_frame,
+                text=text,
+                variable=self._difficulty,
+                value=value
+            )
+            rb.pack(side='left', padx=5)
+
+        # Tags entry
+        tags_frame = ttk.Frame(actions_frame)
+        tags_frame.grid(row=1, column=0, sticky='ew', pady=(0, 10))
+        tags_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(tags_frame, text="Tags:", font=('Arial', 10, 'bold')).grid(
+            row=0, column=0, sticky='w', padx=(0, 10)
+        )
+        self.tags_entry = ttk.Entry(tags_frame)
+        self.tags_entry.grid(row=0, column=1, sticky='ew')
+        ttk.Label(
+            tags_frame,
+            text="(comma-separated, optional)",
+            font=('Arial', 8),
+            foreground='gray'
+        ).grid(row=0, column=2, padx=(5, 0))
+
+        # Action buttons
+        button_frame = ttk.Frame(actions_frame)
+        button_frame.grid(row=2, column=0, sticky='e')
+
+        # Skip button
+        self.skip_button = ttk.Button(
+            button_frame,
+            text="Skip",
+            command=self._skip_word,
+            width=10
+        )
+        self.skip_button.pack(side='left', padx=5)
+
+        # Reject button
+        self.reject_button = ttk.Button(
+            button_frame,
+            text="Reject",
+            command=self._reject_word,
+            width=10
+        )
+        self.reject_button.pack(side='left', padx=5)
+
+        # Approve button
+        self.approve_button = ttk.Button(
+            button_frame,
+            text="Approve",
+            command=self._approve_word,
+            width=10
+        )
+        self.approve_button.pack(side='left', padx=5)
+
+        # Apply styles for button colors
+        try:
+            style = ttk.Style()
+            style.configure('Approve.TButton', font=('Arial', 10, 'bold'))
+            style.configure('Reject.TButton', font=('Arial', 10))
+            self.approve_button.configure(style='Approve.TButton')
+            self.reject_button.configure(style='Reject.TButton')
+        except tk.TclError:
+            pass  # Style may not be supported on all platforms
+
+    def _refresh_sessions(self):
+        """Refresh the list of available sessions."""
+        sessions = get_all_sessions()
+
+        if not sessions:
+            self.session_combo['values'] = []
+            self.session_combo.set('')
+            messagebox.showinfo(
+                "No Sessions",
+                "No processing sessions found. Process some text first."
+            )
+            return
+
+        # Format sessions for display: "session_id (X words)"
+        session_values = []
+        self._session_map = {}  # Map display text to session_id
+
+        for session_id, word_count, created_at in sessions:
+            display_text = f"{session_id} ({word_count} words)"
+            session_values.append(display_text)
+            self._session_map[display_text] = session_id
+
+        self.session_combo['values'] = session_values
+        if session_values:
+            self.session_combo.current(0)
+
+    def _load_session(self):
+        """Load the selected session and display the first word."""
+        selected = self.session_combo.get()
+        if not selected:
+            messagebox.showwarning(
+                "No Session",
+                "Please select a session to load."
+            )
+            return
+
+        # Get session_id from selection
+        if not hasattr(self, '_session_map') or selected not in self._session_map:
+            self._refresh_sessions()
+            return
+
+        session_id = self._session_map[selected]
+
+        # Load words for this session
+        words = get_pending_words(session_id)
+
+        if not words:
+            messagebox.showinfo(
+                "Empty Session",
+                "This session has no pending words to review."
+            )
+            return
+
+        # Update state
+        self._current_session_id = session_id
+        self._words = words
+        self._current_index = 0
+
+        # Display first word
+        self._display_current_word()
+        self._update_button_states()
+
+    def _display_current_word(self):
+        """Display the current word in the word display section."""
+        if not self._words or self._current_index >= len(self._words):
+            self._show_session_complete()
+            return
+
+        # Hide the "no word" message
+        self.no_word_label.grid_remove()
+
+        # Get current word data
+        # Format: (word, lemma, pos, translation, is_regular, session_id, created_at)
+        word_data = self._words[self._current_index]
+        original, lemma, pos, translation, is_regular, session_id, created_at = word_data
+
+        # Update labels
+        self.original_label.configure(text=original)
+        self.lemma_label.configure(text=lemma)
+        self.pos_label.configure(text=pos or "-")
+        self.translation_label.configure(
+            text=translation if translation else "No translation",
+            foreground='black' if translation else 'gray'
+        )
+
+        # Update progress
+        self._update_progress()
+
+        # Reset difficulty to default and clear tags
+        self._difficulty.set(3)
+        self.tags_entry.delete(0, 'end')
+
+    def _update_progress(self):
+        """Update the progress label."""
+        if self._words:
+            total = len(self._words)
+            current = self._current_index + 1
+            self.progress_label.configure(text=f"Word {current} of {total}")
+        else:
+            self.progress_label.configure(text="No session loaded")
+
+    def _update_button_states(self):
+        """Enable or disable action buttons based on current state."""
+        has_words = bool(self._words) and self._current_index < len(self._words)
+
+        state = 'normal' if has_words else 'disabled'
+        self.approve_button.configure(state=state)
+        self.reject_button.configure(state=state)
+        self.skip_button.configure(state=state)
+
+    def _get_tags(self):
+        """Get the list of tags from the entry field."""
+        tags_text = self.tags_entry.get().strip()
+        if not tags_text:
+            return None
+
+        # Split by comma and clean up each tag
+        tags = [tag.strip() for tag in tags_text.split(',')]
+        # Remove empty strings
+        tags = [tag for tag in tags if tag]
+
+        return tags if tags else None
+
+    def _approve_word(self):
+        """Approve the current word and move to the next."""
+        if not self._words or self._current_index >= len(self._words):
+            return
+
+        # Get current word lemma
+        word_data = self._words[self._current_index]
+        lemma = word_data[1]  # lemma is at index 1
+
+        # Get difficulty and tags
+        difficulty = self._difficulty.get()
+        tags = self._get_tags()
+
+        # Approve the word
+        success = approve_word(lemma, self._current_session_id, difficulty, tags)
+
+        if success:
+            # Move to next word
+            self._current_index += 1
+            self._display_current_word()
+            self._update_button_states()
+        else:
+            messagebox.showerror(
+                "Approval Failed",
+                f"Failed to approve word '{lemma}'. It may already exist in the vocabulary."
+            )
+            # Still move to next word since it was removed from temp
+            self._current_index += 1
+            self._display_current_word()
+            self._update_button_states()
+
+    def _reject_word(self):
+        """Reject the current word and move to the next."""
+        if not self._words or self._current_index >= len(self._words):
+            return
+
+        # Get current word lemma
+        word_data = self._words[self._current_index]
+        lemma = word_data[1]  # lemma is at index 1
+
+        # Reject the word
+        success = reject_word(lemma, self._current_session_id)
+
+        if success:
+            # Move to next word
+            self._current_index += 1
+            self._display_current_word()
+            self._update_button_states()
+        else:
+            messagebox.showerror(
+                "Rejection Failed",
+                f"Failed to reject word '{lemma}'."
+            )
+
+    def _skip_word(self):
+        """Skip the current word and move to the next without action."""
+        if not self._words or self._current_index >= len(self._words):
+            return
+
+        # Simply move to next word
+        self._current_index += 1
+        self._display_current_word()
+        self._update_button_states()
+
+    def _show_session_complete(self):
+        """Show the session complete message."""
+        # Clear word display
+        self.original_label.configure(text="-")
+        self.lemma_label.configure(text="-")
+        self.pos_label.configure(text="-")
+        self.translation_label.configure(text="-", foreground='black')
+
+        # Show completion message
+        self.no_word_label.configure(
+            text="Session complete! All words have been reviewed.",
+            foreground='green'
+        )
+        self.no_word_label.grid()
+
+        # Update progress
+        self.progress_label.configure(text="Session complete")
+
+        # Disable action buttons
+        self._update_button_states()
+
+        # Clear session state
+        self._words = []
+        self._current_session_id = None
+
+    def refresh(self):
+        """Public method to refresh the sessions list (can be called from other tabs)."""
+        self._refresh_sessions()

--- a/tests/test_review_queue_tab.py
+++ b/tests/test_review_queue_tab.py
@@ -1,0 +1,400 @@
+"""Test the Review Queue tab UI."""
+
+import sys
+import os
+import tkinter as tk
+from unittest.mock import patch, MagicMock
+
+# Add src/ui to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'ui'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from tabs.review_queue_tab import ReviewQueueTab
+
+
+class TestReviewQueueTabUI:
+    """Test Review Queue tab UI elements."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.root = tk.Tk()
+        self.tab = ReviewQueueTab(self.root)
+        self.root.update_idletasks()
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        self.root.destroy()
+
+    def test_tab_initialization(self):
+        """Test that tab initializes correctly."""
+        assert self.tab is not None
+        assert self.tab._current_session_id is None
+        assert self.tab._words == []
+        assert self.tab._current_index == 0
+
+    def test_difficulty_default_value(self):
+        """Test that difficulty defaults to 3 (Medium)."""
+        assert self.tab._difficulty.get() == 3
+
+    def test_session_combo_exists(self):
+        """Test that session combobox exists."""
+        assert hasattr(self.tab, 'session_combo')
+        assert self.tab.session_combo is not None
+
+    def test_load_button_exists(self):
+        """Test that load button exists."""
+        assert hasattr(self.tab, 'load_button')
+
+    def test_action_buttons_exist(self):
+        """Test that all action buttons exist."""
+        assert hasattr(self.tab, 'approve_button')
+        assert hasattr(self.tab, 'reject_button')
+        assert hasattr(self.tab, 'skip_button')
+
+    def test_action_buttons_initially_disabled(self):
+        """Test that action buttons are disabled when no session loaded."""
+        assert 'disabled' in str(self.tab.approve_button['state'])
+        assert 'disabled' in str(self.tab.reject_button['state'])
+        assert 'disabled' in str(self.tab.skip_button['state'])
+
+    def test_word_labels_exist(self):
+        """Test that all word display labels exist."""
+        assert hasattr(self.tab, 'original_label')
+        assert hasattr(self.tab, 'lemma_label')
+        assert hasattr(self.tab, 'pos_label')
+        assert hasattr(self.tab, 'translation_label')
+
+    def test_progress_label_exists(self):
+        """Test that progress label exists."""
+        assert hasattr(self.tab, 'progress_label')
+        assert 'No session loaded' in self.tab.progress_label.cget('text')
+
+    def test_tags_entry_exists(self):
+        """Test that tags entry field exists."""
+        assert hasattr(self.tab, 'tags_entry')
+
+
+class TestReviewQueueTabState:
+    """Test Review Queue tab state management."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.root = tk.Tk()
+        self.tab = ReviewQueueTab(self.root)
+        self.root.update_idletasks()
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        self.root.destroy()
+
+    def test_update_button_states_enabled(self):
+        """Test that buttons are enabled when words are loaded."""
+        # Simulate loaded words
+        self.tab._words = [('test', 'test', 'NOUN', 'test', True, 'session1', '2024-01-01')]
+        self.tab._current_index = 0
+
+        self.tab._update_button_states()
+
+        assert str(self.tab.approve_button['state']) in ['normal', 'enabled', '!disabled']
+        assert str(self.tab.reject_button['state']) in ['normal', 'enabled', '!disabled']
+        assert str(self.tab.skip_button['state']) in ['normal', 'enabled', '!disabled']
+
+    def test_update_button_states_disabled_when_past_end(self):
+        """Test that buttons are disabled when index exceeds words."""
+        self.tab._words = [('test', 'test', 'NOUN', 'test', True, 'session1', '2024-01-01')]
+        self.tab._current_index = 1  # Past the end
+
+        self.tab._update_button_states()
+
+        assert 'disabled' in str(self.tab.approve_button['state'])
+
+    def test_get_tags_empty(self):
+        """Test that empty tags return None."""
+        self.tab.tags_entry.delete(0, 'end')
+        assert self.tab._get_tags() is None
+
+    def test_get_tags_single(self):
+        """Test parsing single tag."""
+        self.tab.tags_entry.delete(0, 'end')
+        self.tab.tags_entry.insert(0, 'medical')
+        tags = self.tab._get_tags()
+        assert tags == ['medical']
+
+    def test_get_tags_multiple(self):
+        """Test parsing multiple tags."""
+        self.tab.tags_entry.delete(0, 'end')
+        self.tab.tags_entry.insert(0, 'medical, difficult, technical')
+        tags = self.tab._get_tags()
+        assert tags == ['medical', 'difficult', 'technical']
+
+    def test_get_tags_with_whitespace(self):
+        """Test that tags are trimmed."""
+        self.tab.tags_entry.delete(0, 'end')
+        self.tab.tags_entry.insert(0, '  medical  ,  difficult  ')
+        tags = self.tab._get_tags()
+        assert tags == ['medical', 'difficult']
+
+    def test_get_tags_empty_strings_removed(self):
+        """Test that empty strings are removed from tags."""
+        self.tab.tags_entry.delete(0, 'end')
+        self.tab.tags_entry.insert(0, 'medical,,difficult,')
+        tags = self.tab._get_tags()
+        assert tags == ['medical', 'difficult']
+
+
+class TestReviewQueueTabBehavior:
+    """Test Review Queue tab behavior."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.root = tk.Tk()
+        self.tab = ReviewQueueTab(self.root)
+        self.root.update_idletasks()
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        self.root.destroy()
+
+    def test_display_current_word(self):
+        """Test that word data is displayed correctly."""
+        # Set up test word
+        self.tab._words = [
+            ('original', 'lemma', 'NOUN', 'translation', True, 'session1', '2024-01-01')
+        ]
+        self.tab._current_index = 0
+
+        self.tab._display_current_word()
+
+        assert self.tab.original_label.cget('text') == 'original'
+        assert self.tab.lemma_label.cget('text') == 'lemma'
+        assert self.tab.pos_label.cget('text') == 'NOUN'
+        assert self.tab.translation_label.cget('text') == 'translation'
+
+    def test_display_word_without_translation(self):
+        """Test display when word has no translation."""
+        self.tab._words = [
+            ('original', 'lemma', 'VERB', None, True, 'session1', '2024-01-01')
+        ]
+        self.tab._current_index = 0
+
+        self.tab._display_current_word()
+
+        assert self.tab.translation_label.cget('text') == 'No translation'
+
+    def test_update_progress(self):
+        """Test progress label updates correctly."""
+        self.tab._words = [
+            ('word1', 'lemma1', 'NOUN', None, True, 's1', '2024-01-01'),
+            ('word2', 'lemma2', 'VERB', None, True, 's1', '2024-01-01'),
+            ('word3', 'lemma3', 'ADJ', None, True, 's1', '2024-01-01'),
+        ]
+        self.tab._current_index = 1
+
+        self.tab._update_progress()
+
+        assert 'Word 2 of 3' in self.tab.progress_label.cget('text')
+
+    def test_skip_word_advances_index(self):
+        """Test that skip advances to next word."""
+        self.tab._words = [
+            ('word1', 'lemma1', 'NOUN', None, True, 's1', '2024-01-01'),
+            ('word2', 'lemma2', 'VERB', None, True, 's1', '2024-01-01'),
+        ]
+        self.tab._current_index = 0
+        self.tab._current_session_id = 's1'
+
+        self.tab._skip_word()
+
+        assert self.tab._current_index == 1
+
+    def test_difficulty_reset_on_new_word(self):
+        """Test that difficulty resets to default on new word."""
+        self.tab._words = [
+            ('word1', 'lemma1', 'NOUN', None, True, 's1', '2024-01-01'),
+        ]
+        self.tab._current_index = 0
+        self.tab._difficulty.set(1)  # Change from default
+
+        self.tab._display_current_word()
+
+        assert self.tab._difficulty.get() == 3  # Reset to default
+
+    def test_tags_cleared_on_new_word(self):
+        """Test that tags entry is cleared on new word."""
+        self.tab._words = [
+            ('word1', 'lemma1', 'NOUN', None, True, 's1', '2024-01-01'),
+        ]
+        self.tab._current_index = 0
+        self.tab.tags_entry.insert(0, 'some tags')
+
+        self.tab._display_current_word()
+
+        assert self.tab.tags_entry.get() == ''
+
+    @patch('tabs.review_queue_tab.get_all_sessions')
+    def test_refresh_sessions_with_data(self, mock_get_sessions):
+        """Test refreshing sessions populates the combobox."""
+        mock_get_sessions.return_value = [
+            ('session1', 5, '2024-01-01'),
+            ('session2', 10, '2024-01-02'),
+        ]
+
+        self.tab._refresh_sessions()
+
+        values = self.tab.session_combo['values']
+        assert len(values) == 2
+        assert 'session1' in values[0]
+        assert '5 words' in values[0]
+
+    @patch('tabs.review_queue_tab.get_all_sessions')
+    @patch('tkinter.messagebox.showinfo')
+    def test_refresh_sessions_empty(self, mock_info, mock_get_sessions):
+        """Test refreshing sessions shows message when empty."""
+        mock_get_sessions.return_value = []
+
+        self.tab._refresh_sessions()
+
+        mock_info.assert_called_once()
+        assert 'No' in mock_info.call_args[0][0]
+
+    @patch('tkinter.messagebox.showwarning')
+    def test_load_session_no_selection(self, mock_warning):
+        """Test loading session with no selection shows warning."""
+        self.tab.session_combo.set('')
+
+        self.tab._load_session()
+
+        mock_warning.assert_called_once()
+
+    @patch('tabs.review_queue_tab.approve_word')
+    def test_approve_word_calls_backend(self, mock_approve):
+        """Test that approve calls the backend function."""
+        mock_approve.return_value = True
+
+        self.tab._words = [
+            ('original', 'lemma', 'NOUN', 'trans', True, 'session1', '2024-01-01')
+        ]
+        self.tab._current_index = 0
+        self.tab._current_session_id = 'session1'
+        self.tab._difficulty.set(2)
+
+        self.tab._approve_word()
+
+        mock_approve.assert_called_once_with('lemma', 'session1', 2, None)
+
+    @patch('tabs.review_queue_tab.approve_word')
+    def test_approve_word_with_tags(self, mock_approve):
+        """Test that approve passes tags to backend."""
+        mock_approve.return_value = True
+
+        self.tab._words = [
+            ('original', 'lemma', 'NOUN', 'trans', True, 'session1', '2024-01-01')
+        ]
+        self.tab._current_index = 0
+        self.tab._current_session_id = 'session1'
+        self.tab.tags_entry.insert(0, 'medical, technical')
+
+        self.tab._approve_word()
+
+        mock_approve.assert_called_once()
+        call_args = mock_approve.call_args[0]
+        assert call_args[3] == ['medical', 'technical']
+
+    @patch('tabs.review_queue_tab.reject_word')
+    def test_reject_word_calls_backend(self, mock_reject):
+        """Test that reject calls the backend function."""
+        mock_reject.return_value = True
+
+        self.tab._words = [
+            ('original', 'lemma', 'NOUN', 'trans', True, 'session1', '2024-01-01')
+        ]
+        self.tab._current_index = 0
+        self.tab._current_session_id = 'session1'
+
+        self.tab._reject_word()
+
+        mock_reject.assert_called_once_with('lemma', 'session1')
+
+    def test_session_complete_clears_state(self):
+        """Test that session complete clears the state."""
+        self.tab._words = [('test', 'test', 'NOUN', 'test', True, 's1', '2024-01-01')]
+        self.tab._current_session_id = 's1'
+        self.tab._current_index = 0
+
+        self.tab._show_session_complete()
+
+        assert self.tab._words == []
+        assert self.tab._current_session_id is None
+        assert 'Session complete' in self.tab.progress_label.cget('text')
+
+
+class TestReviewQueueTabIntegration:
+    """Test Review Queue tab integration scenarios."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.root = tk.Tk()
+        self.tab = ReviewQueueTab(self.root)
+        self.root.update_idletasks()
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        self.root.destroy()
+
+    @patch('tabs.review_queue_tab.approve_word')
+    def test_approve_advances_to_next_word(self, mock_approve):
+        """Test that approving advances to the next word."""
+        mock_approve.return_value = True
+
+        self.tab._words = [
+            ('word1', 'lemma1', 'NOUN', 'trans1', True, 's1', '2024-01-01'),
+            ('word2', 'lemma2', 'VERB', 'trans2', True, 's1', '2024-01-01'),
+        ]
+        self.tab._current_index = 0
+        self.tab._current_session_id = 's1'
+
+        self.tab._approve_word()
+
+        assert self.tab._current_index == 1
+        assert self.tab.lemma_label.cget('text') == 'lemma2'
+
+    @patch('tabs.review_queue_tab.reject_word')
+    def test_reject_advances_to_next_word(self, mock_reject):
+        """Test that rejecting advances to the next word."""
+        mock_reject.return_value = True
+
+        self.tab._words = [
+            ('word1', 'lemma1', 'NOUN', 'trans1', True, 's1', '2024-01-01'),
+            ('word2', 'lemma2', 'VERB', 'trans2', True, 's1', '2024-01-01'),
+        ]
+        self.tab._current_index = 0
+        self.tab._current_session_id = 's1'
+
+        self.tab._reject_word()
+
+        assert self.tab._current_index == 1
+
+    @patch('tabs.review_queue_tab.approve_word')
+    def test_approve_last_word_shows_complete(self, mock_approve):
+        """Test that approving last word shows session complete."""
+        mock_approve.return_value = True
+
+        self.tab._words = [
+            ('word1', 'lemma1', 'NOUN', 'trans1', True, 's1', '2024-01-01'),
+        ]
+        self.tab._current_index = 0
+        self.tab._current_session_id = 's1'
+
+        self.tab._approve_word()
+
+        assert 'Session complete' in self.tab.progress_label.cget('text')
+
+
+def run_tests():
+    """Run all tests."""
+    import pytest
+    pytest.main([__file__, '-v'])
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary
- Implemented complete Review Queue tab for reviewing and approving/rejecting processed words
- Added session selection with dropdown and refresh functionality
- Created word display section showing original form, lemma, POS, and translation
- Implemented difficulty selection with 5 radio buttons (defaults to Medium)
- Added optional tags entry field with comma-separated parsing
- Integrated with database functions: get_all_sessions, get_pending_words, approve_word, reject_word
- Added progress tracking and session complete handling

## Test plan
- [x] Run `python -m pytest tests/test_review_queue_tab.py -v` - 31 tests pass
- [x] Run `python -m pytest tests/test_ui_structure.py -v` - UI structure test passes
- [ ] Manual test: Load a session and verify words display correctly
- [ ] Manual test: Approve a word with difficulty and tags, verify it's saved
- [ ] Manual test: Reject a word, verify it's removed from temp database
- [ ] Manual test: Skip through words and verify progress counter updates

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)